### PR TITLE
fix: get nvim-navic context before update

### DIFF
--- a/lua/barbecue/ui/components.lua
+++ b/lua/barbecue/ui/components.lua
@@ -189,6 +189,9 @@ function M.context(winnr, bufnr)
   if not config.user.show_navic then return {} end
   if not navic.is_available() then return {} end
 
+  local cursor_pos = vim.api.nvim_win_get_cursor(winnr)
+  require("nvim-navic.lib").update_context(bufnr, cursor_pos)
+
   local nestings = navic.get_data(bufnr)
   if nestings == nil then return {} end
 


### PR DESCRIPTION
Got this from https://github.com/utilyre/barbecue.nvim/pull/120/files